### PR TITLE
Some editing for the peer authentication BIP draft

### DIFF
--- a/bip-undef-0.mediawiki
+++ b/bip-undef-0.mediawiki
@@ -9,19 +9,19 @@
 
 == Abstract ==
 
-This BIP describes a way how peers can authenticate – without opening fingerprinting possibilities – to other peers to guarantee ownership and/or allowing to access additional or limited services.
+This BIP describes a way for peers to authenticate to other peers to guarantee node ownership and/or allow peers to access additional or limited node services, without the possibility of fingerprinting.
 
 == Motivation ==
 
-We assume peer operators want to limit the access of different services or increase datastream priorities to a selective subset of peers. Also we assume peers want to connect to specific peers to broadcast or filter transactions (or similar action that reveals sensitive informations) and therefore they want to authenticate the remote peer and make sure that they have not connected to a MITM. 
+We assume peer operators want to limit the access of different node services or increase datastream priorities to a selective subset of peers. Also we assume that peers want to connect to specific peers to broadcast or filter transactions (or similar actions that reveal sensitive informations) and therefore operators want to authenticate the remote peer and ensure that they have not connected to a MITM (man-in-the-middle) attacker.
 
-Benefits with peer authentication:
-* Peers could detect MITM attacks when connecting to known peers
-* Peers could allow resource hungry transaction filtering only to specific peers
-* Peers could allow access to sensitive information that can lead to node fingerprinting (fee estimation)
-* Peers could allow custom message types (private extensions) to authenticated peers
+Benefits of peer authentication:
+* Peers can detect MITM attacks when connecting to known peers
+* Peers can allow resource hungry transaction filtering only to specific peers
+* Peers can allow access to sensitive information that can lead to node fingerprinting (fee estimation)
+* Peers can allow custom message types (private extensions) to authenticated peers
 
-A simple authentication scheme based on elliptic cryptography will allow peers to identify each other and selective allow access to restricted services or reject the connection if the identity could not be verified.
+A simple authentication scheme based on elliptic cryptography will allow peers to identify each other and selectively allow access to restricted services or reject the connection if the peer identity cannot be verified.
 
 == Specification ==
 
@@ -31,24 +31,24 @@ The authentication scheme proposed in this BIP uses ECDSA, '''secrets will never
 
 The '''encryption-session-ID''' is available once channels are encrypted (according to BIP-151 [1]).
 
-The identity-public-keys used for the authentication must be pre-shared over a different channel (Mail/PGP, physical paper exchange, etc.). This BIP does not cover a "trust on first use" (TOFU) concept.
+The identity-public-keys used for the authentication must be pre-shared over a different channel (mail/PGP, physical paper exchange, etc.). This BIP does not cover a "trust on first use" (TOFU) concept.
 
 The authentication state must be kept until the encryption/connection terminates.
 
-Only one authentication process is allowed per connection. Re-authenticate require re-establishing the connection.
+Only one authentication process is allowed per connection. Re-authentication require re-establishing the connection.
 
 === Known-peers and authorized-peers database ===
-Each peer that supports p2p authentication must provide two users editable "databases"
+Each peer that supports p2p authentication must provide two user-editable "databases".
 
 # '''known-peers''' contains known identity-public-keys together with a network identifier (IP & port), similar to the "known-host" file supported by openssh.
 # '''authorized-peers''' contains authorized identity-public-keys
 
 === Local identity key management ===
-Each peer can configure multiple identity-keys (ECC, 32 bytes). Peers should make sure, each network interface (IPv4, IPv6, tor) has its own identity-key (otherwise it would be possible to link a tor address to a IPvX address).
+Each peer can configure multiple identity-keys (ECC, 32 bytes). Peers should make sure that each network interface (IPv4, IPv6, tor) has its own identity-key (otherwise it would be possible to link a tor address to a IPvX address).
 The identity-public-key(s) can be shared over a different channel with other node-operators (or non-validating clients) to grant authorized access.
 
 === Authentication procedure ===
-Authentication after this BIP will require both sides to authenticate. Signatures/public-keys will only be revealed if the remote peer could prove that they already know the remote identity-public-key.
+Authentication based on this BIP will require both sides to authenticate. Signatures/public-keys will only be revealed if the remote peer can prove that they already know the remote identity-public-key.
 
 # -> Requesting peer sends <code>AUTHCHALLENGE</code> (hash)
 # <- Responding peer sends <code>AUTHREPLY</code> (signature)
@@ -56,10 +56,10 @@ Authentication after this BIP will require both sides to authenticate. Signature
 # <- Responding peer sends <code>AUTHCHALLENGE</code> (hash)
 # -> Requesting peer sends <code>AUTHREPLY</code> (signature)
 
-For privacy reasons, dropping the connection or aborting during the authentication process must not be possible.
+For privacy reasons, dropping the connection or aborting during the authentication process must not be allowed.
 
 === <code>AUTHCHALLENGE</code> message ===
-A peer can send an authentication challenge to see if the responding peer can produce a valid signature with the expected responding peers identity-public-key by sending an <code>AUTHCHALLENGE</code>-message to the remote peer.
+A peer can send an authentication challenge to see if the responding peer can produce a valid signature with the expected responding peer's identity-public-key by sending an <code>AUTHCHALLENGE</code>-message to the remote peer.
 
 The responding peer needs to check if the hash matches the hash calculated with his own local identity-public-key. Fingerprinting the requesting peer is not possible.
 
@@ -81,9 +81,9 @@ A peer must reply an <code>AUTHCHALLENGE</code>-message with an <code>AUTHREPLY<
 | 64bytes || signature || normalized comp.-signature || A signature of the encryption-session-ID done with the identity-key
 |}
 
-If the challenge-hash from the <code>AUTHCHALLENGE</code>-message did not match the local authentication public-key, the signature must contain 64bytes of zeros.
+If the challenge-hash from the <code>AUTHCHALLENGE</code>-message did not match the local authentication public-key, the signature must contain 64 bytes of zeros.
 
-The requesting peer can check the responding peers identity by checking the validity of the sent signature against with the pre-shared remote peers identity-public-key.
+The requesting peer can check the responding peer's identity by checking the validity of the sent signature against with the pre-shared remote peers identity-public-key.
 
 If the signature was invalid, the requesting peer must still proceed with the authentication by sending an <code>AUTHPROPOSE</code>-message with 32 random bytes.
 
@@ -92,7 +92,7 @@ A peer can propose authentication of the channel by sending an <code>AUTHPROPOSE
 
 If the signature sent in <code>AUTHREPLY</code> was invalid, the peer must still send an <code>AUTHPROPOSE</code>-message containing 32 random bytes.
 
-The <code>AUTHPROPOSE</code> message must be answered with an <code>AUTHCHALLENGE</code>-message – even if the proposed requesting-peers identity-public-key has not been found in the authorized_peers database. In case of no match, the responding <code>AUTHCHALLENGE</code>-message must contains 32 bytes of zeros.
+The <code>AUTHPROPOSE</code> message must be answered with an <code>AUTHCHALLENGE</code>-message - even if the proposed requesting-peers identity-public-key has not been found in the authorized-peers database. In case of no match, the responding <code>AUTHCHALLENGE</code>-message must contains 32 bytes of zeros.
 
 {|class="wikitable"
 ! Field Size !! Description !! Data type !! Comments
@@ -102,15 +102,15 @@ The <code>AUTHPROPOSE</code> message must be answered with an <code>AUTHCHALLENG
 
 == Post-Authentication Re-Keying ==
 
-After the second <code>AUTHREPLY</code> message (requesting peers signature -> responding peer), both clients must re-key the symmetric encryption according to BIP151 while using '''a slightly  different re-key key derivation hash'''.
+After the second <code>AUTHREPLY</code> message (requesting peer's signature -> responding peer), both clients must re-key the symmetric encryption according to BIP151 while using '''a slightly different re-key key derivation hash'''.
 
-They both re-key with <code>hash(encryption-session-ID || old_symmetric_cipher_key || requesting-peer-identity-public-key || responding-peer-identity-public-key)</code>
+Both peers re-key with <code>hash(encryption-session-ID || old_symmetric_cipher_key || requesting-peer-identity-public-key || responding-peer-identity-public-key)</code>
 
 == Identity-Addresses ==
 The peers should display/log the identity-public-key as an identity-address to the users, which is a base58-check encoded ripemd160(sha256) hash. The purpose of this is for better visual comparison (logs, accept-dialogs).
 The base58check identity byte is <code>0x0F</code> followed by an identity-address version number (=<code>0xFF01</code>).
 
-An identity address would look like <code>TfG4ScDgysrSpodWD4Re5UtXmcLbY5CiUHA</code> and can be interpreted as a remote peers fingerprint.
+An identity address would look like <code>TfG4ScDgysrSpodWD4Re5UtXmcLbY5CiUHA</code> and can be interpreted as a remote peer's fingerprint.
 
 == Compatibility ==
 
@@ -120,7 +120,7 @@ This proposal is backward compatible. Non-supporting peers will ignore the new <
 
 Before authentication (once during peer setup or upgrade)
 # Requesting peer and responding peer create each an identity-keypair (standard ECC priv/pubkey)
-# Requesting and responding peer share the identity-public-key over a different channel (PGP mail, physical exchange, etc.)
+# Requesting and responding peer share the identity-public-key over a different channel (mail/PGP, physical paper exchange, etc.)
 # Responding peer stores requesting peers identity-public-key in its authorized-peers database (A)
 # Requesting peer stores responding peers identity-public-key in its known-peers database together with its IP and port (B)
 
@@ -158,7 +158,7 @@ Authentication
 
 == Disadvantages ==
 
-The protocol may be slow if a peer has a large authorized-peers database due to the requirement of iterating and hashing over all available authorized peers identity-public-keys.
+The protocol may be slow if a peer has a large authorized-peers database due to the requirement of iterating and hashing over all available authorized peer identity-public-keys.
 
 == Reference implementation ==
 
@@ -168,6 +168,7 @@ The protocol may be slow if a peer has a large authorized-peers database due to 
 
 == Acknowledgements ==
 * Gregory Maxwell and Pieter Wuille for most of the ideas in this BIP.
+* Bryan Bishop for editing.
 
 == Copyright ==
 This work is placed in the public domain.

--- a/bip-undef-0.mediawiki
+++ b/bip-undef-0.mediawiki
@@ -1,0 +1,175 @@
+<pre>
+  BIP: ???
+  Title: Peer Authentication
+  Author: Jonas Schnelli <dev@jonasschnelli.ch>
+  Status: Draft
+  Type: Standards Track
+  Created: 2016-03-23
+</pre>
+
+== Abstract ==
+
+This BIP describes a way how peers can authenticate – without opening fingerprinting possibilities – to other peers to guarantee ownership and/or allowing to access additional or limited services.
+
+== Motivation ==
+
+We assume peer operators want to limit the access of different services or increase datastream priorities to a selective subset of peers. Also we assume peers want to connect to specific peers to broadcast or filter transactions (or similar action that reveals sensitive informations) and therefore they want to authenticate the remote peer and make sure that they have not connected to a MITM. 
+
+Benefits with peer authentication:
+* Peers could detect MITM attacks when connecting to known peers
+* Peers could allow resource hungry transaction filtering only to specific peers
+* Peers could allow access to sensitive information that can lead to node fingerprinting (fee estimation)
+* Peers could allow custom message types (private extensions) to authenticated peers
+
+A simple authentication scheme based on elliptic cryptography will allow peers to identify each other and selective allow access to restricted services or reject the connection if the identity could not be verified.
+
+== Specification ==
+
+The authentication scheme proposed in this BIP uses ECDSA, '''secrets will never be transmitted'''.
+
+'''Authentication initialization must only happen if encrypted channels have been established (according to BIP-151 [1]).'''
+
+The '''encryption-session-ID''' is available once channels are encrypted (according to BIP-151 [1]).
+
+The identity-public-keys used for the authentication must be pre-shared over a different channel (Mail/PGP, physical paper exchange, etc.). This BIP does not cover a "trust on first use" (TOFU) concept.
+
+The authentication state must be kept until the encryption/connection terminates.
+
+Only one authentication process is allowed per connection. Re-authenticate require re-establishing the connection.
+
+=== Known-peers and authorized-peers database ===
+Each peer that supports p2p authentication must provide two users editable "databases"
+
+# '''known-peers''' contains known identity-public-keys together with a network identifier (IP & port), similar to the "known-host" file supported by openssh.
+# '''authorized-peers''' contains authorized identity-public-keys
+
+=== Local identity key management ===
+Each peer can configure multiple identity-keys (ECC, 32 bytes). Peers should make sure, each network interface (IPv4, IPv6, tor) has its own identity-key (otherwise it would be possible to link a tor address to a IPvX address).
+The identity-public-key(s) can be shared over a different channel with other node-operators (or non-validating clients) to grant authorized access.
+
+=== Authentication procedure ===
+Authentication after this BIP will require both sides to authenticate. Signatures/public-keys will only be revealed if the remote peer could prove that they already know the remote identity-public-key.
+
+# -> Requesting peer sends <code>AUTHCHALLENGE</code> (hash)
+# <- Responding peer sends <code>AUTHREPLY</code> (signature)
+# -> Requesting peer sends <code>AUTHPROPOSE</code> (hash)
+# <- Responding peer sends <code>AUTHCHALLENGE</code> (hash)
+# -> Requesting peer sends <code>AUTHREPLY</code> (signature)
+
+For privacy reasons, dropping the connection or aborting during the authentication process must not be possible.
+
+=== <code>AUTHCHALLENGE</code> message ===
+A peer can send an authentication challenge to see if the responding peer can produce a valid signature with the expected responding peers identity-public-key by sending an <code>AUTHCHALLENGE</code>-message to the remote peer.
+
+The responding peer needs to check if the hash matches the hash calculated with his own local identity-public-key. Fingerprinting the requesting peer is not possible.
+
+{|class="wikitable"
+! Field Size !! Description !! Data type !! Comments
+|-
+| 32bytes || challenge-hash || hash || <code>hash(encryption-session-ID || challenge_type || remote-peers-expected-identity-public-key)</code>
+|}
+
+
+<code>challenge_type</code> is a single character. <code>i</code> if the <code>AUTHCHALLENGE</code>-message is the first, requesting challenge or <code>r</code> if it's the second, remote peers challenge message.
+
+=== <code>AUTHREPLY</code> message ===
+A peer must reply an <code>AUTHCHALLENGE</code>-message with an <code>AUTHREPLY</code>-message.
+
+{|class="wikitable"
+! Field Size !! Description !! Data type !! Comments
+|-
+| 64bytes || signature || normalized comp.-signature || A signature of the encryption-session-ID done with the identity-key
+|}
+
+If the challenge-hash from the <code>AUTHCHALLENGE</code>-message did not match the local authentication public-key, the signature must contain 64bytes of zeros.
+
+The requesting peer can check the responding peers identity by checking the validity of the sent signature against with the pre-shared remote peers identity-public-key.
+
+If the signature was invalid, the requesting peer must still proceed with the authentication by sending an <code>AUTHPROPOSE</code>-message with 32 random bytes.
+
+=== <code>AUTHPROPOSE</code> message ===
+A peer can propose authentication of the channel by sending an <code>AUTHPROPOSE</code>-message to the remote peer.
+
+If the signature sent in <code>AUTHREPLY</code> was invalid, the peer must still send an <code>AUTHPROPOSE</code>-message containing 32 random bytes.
+
+The <code>AUTHPROPOSE</code> message must be answered with an <code>AUTHCHALLENGE</code>-message – even if the proposed requesting-peers identity-public-key has not been found in the authorized_peers database. In case of no match, the responding <code>AUTHCHALLENGE</code>-message must contains 32 bytes of zeros.
+
+{|class="wikitable"
+! Field Size !! Description !! Data type !! Comments
+|-
+| 32bytes || auth-propose-hash || hash || <code>hash(encryption-session-ID || "p" || identity-public-key)</code>
+|}
+
+== Post-Authentication Re-Keying ==
+
+After the second <code>AUTHREPLY</code> message (requesting peers signature -> responding peer), both clients must re-key the symmetric encryption according to BIP151 while using '''a slightly  different re-key key derivation hash'''.
+
+They both re-key with <code>hash(encryption-session-ID || old_symmetric_cipher_key || requesting-peer-identity-public-key || responding-peer-identity-public-key)</code>
+
+== Identity-Addresses ==
+The peers should display/log the identity-public-key as an identity-address to the users, which is a base58-check encoded ripemd160(sha256) hash. The purpose of this is for better visual comparison (logs, accept-dialogs).
+The base58check identity byte is <code>0x0F</code> followed by an identity-address version number (=<code>0xFF01</code>).
+
+An identity address would look like <code>TfG4ScDgysrSpodWD4Re5UtXmcLbY5CiUHA</code> and can be interpreted as a remote peers fingerprint.
+
+== Compatibility ==
+
+This proposal is backward compatible. Non-supporting peers will ignore the new <code>AUTH*</code> messages.
+
+== Example of an auth interaction ==
+
+Before authentication (once during peer setup or upgrade)
+# Requesting peer and responding peer create each an identity-keypair (standard ECC priv/pubkey)
+# Requesting and responding peer share the identity-public-key over a different channel (PGP mail, physical exchange, etc.)
+# Responding peer stores requesting peers identity-public-key in its authorized-peers database (A)
+# Requesting peer stores responding peers identity-public-key in its known-peers database together with its IP and port (B)
+
+Encryption
+# Encrypted channels must be established (according to BIP-151 [1])
+
+Authentication
+# Requesting peer sends an <code>AUTHCHALLENGE</code> message
+  AUTHCHALLENGE:
+    [32 bytes, hash(encryption-session-ID || "i" || <remote-peers-expected-identity-public-key>)]
+
+# Responding peer does create the same hash <code>(encryption-session-ID || "i" || <remote-peers-expected-identity-public-key>)</code> with its local identity-public-key
+# If the hash does not match, response with an <code>AUTHREPLY</code> message containing 64bytes of zeros.
+# In case of a match, response with an <code>AUTHREPLY</code> message
+  AUTHREPLY:
+    [64 bytes normalized compact ECDSA signature (H)] (sig of the encryption-session-ID done with the identity-key)
+
+# Requesting peer does verify the signature with the <code>remote-peers-identity-public-key</code>
+# If the signature is invalid, requesting peer answers with an <code>AUTHREPLY</code> message containing 32 random bytes
+# In case of a valid signature, requesting peer sends an <code>AUTHPROPOSE</code> message
+  AUTHPROPOSE:
+    [32 bytes, hash(encryption-session-ID || "p" || <client-identity-public-key>)]
+
+# Responding peer iterates over authorized-peers database (A), hashes the identical data and looks for a match.
+# If the hash does not match, responding peer answer with an <code>AUTHCHALLENGE</code> message containing 32 bytes of zeros.
+# In case of a match, responding peer sends an <code>AUTHCHALLENGE</code> message with the hashed client public-key
+  AUTHCHALLENGE:
+    [32 bytes, hash(encryption-session-ID || "r" || <client-identity-public-key>)]
+# Requesting peer sends an <code>AUTHREPLY</code> message containing 64 bytes of zeros if server failed to authenticate
+# Otherwise, response with signature in the <code>AUTHREPLY</code> message
+  AUTHREPLY:
+    [64 bytes normalized compact ECDSA signature (H)] (sig of the encryption-session-ID done with the identity-key)
+# Responding peer must verify the signature and can grant access to restricted services.
+# Both peers re-key the encryption after BIP151 including the requesting-peer-identity-public-key and responding-peer-identity-public-key
+
+== Disadvantages ==
+
+The protocol may be slow if a peer has a large authorized-peers database due to the requirement of iterating and hashing over all available authorized peers identity-public-keys.
+
+== Reference implementation ==
+
+== References ==
+
+* [1] [[bip-0151.mediawiki|BIP 151: Peer-to-Peer Communication Encryption]]
+
+== Acknowledgements ==
+* Gregory Maxwell and Pieter Wuille for most of the ideas in this BIP.
+
+== Copyright ==
+This work is placed in the public domain.
+
+


### PR DESCRIPTION
Various edits for the peer authentication BIP draft. Mostly these edits are related to grammar and pluralization and also using consistent terminology throughout the doc.

I think it would be useful to include a section describing the privacy concerns of leaking sensitive information about peer authentication and peer connectivity. For example, some readers may not be familiar with the goals of inhibiting transaction trickle graph analysis techniques. In fact, some readers may not be aware of adversaries focusing on transaction trickle tracking.

I also sent some comments over IRC. In particular:
- Change from "For privacy reasons, dropping the connection or aborting during the authentication process must not be possible." --> to: "For privacy reasons, dropping the connection or aborting during the authentication process must not be allowed." I think this change is correct because there's no way to ensure that dropping a connection is impossible, but it's easy to reject a connection and session once either side drops the connection.
- "This proposal is backward compatible" <--- needs clarification, readers may be unfamiliar with the previous peer protocol
